### PR TITLE
feat: document PII limitation control-level gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ This project makes those deltas explicit, traceable, and machine-readable.
 
 ## Gap Summary
 
-Controls where CJIS v6.0 imposes requirements beyond the FedRAMP High baseline:
+The gap analysis distinguishes two categories of gaps between CJIS v6.0 and FedRAMP High:
+
+- **Implementation-level deltas** — controls present in both baselines, where CJIS imposes stricter parameters, scope, or methodology (e.g., CJIS requires fingerprint-based background checks for PS-3, while FedRAMP allows the organization to define screening method).
+- **Control-level gaps** — controls present in the CJIS v6.0 baseline but absent from FedRAMP High entirely. An agency running FedRAMP High must implement these from scratch to satisfy CJIS. These are concentrated in the NIST 800-53 Rev 5 privacy overlay, reflecting CJI's status as sensitive personal data.
+
+### Implementation-Level Deltas
+
+Controls where CJIS v6.0 imposes stricter requirements than the FedRAMP High baseline:
 
 | NIST 800-53 Rev 5 | FedRAMP High | CJIS v6.0 Delta | Category |
 |--------------------|:------------:|------------------|----------|
@@ -28,7 +35,18 @@ Controls where CJIS v6.0 imposes requirements beyond the FedRAMP High baseline:
 | PE-17 Alternate Work Site | Authorize alternate sites | Specific controls for remote CJI access locations | Physical/Environmental |
 | AT-2 Awareness Training | Annual security training | CJIS Security Awareness Training within 6 months of CJI access, biennial refresher | Training |
 
-> **Note:** This table represents the known deltas identified during initial scoping. The full analysis may surface additional controls where CJIS requirements exceed, refine, or add specificity beyond FedRAMP High.
+### Control-Level Gaps
+
+Controls in the CJIS v6.0 baseline that are not in FedRAMP High. Identified via OSCAL baseline comparison (CJIS v6.0: 302 controls, FedRAMP High: 410 controls, 287 shared, 15 CJIS-only). Documentation and OSCAL data for these controls are being added across subsequent releases.
+
+| Count | Category | Controls |
+|-------|----------|----------|
+| 6 | Privacy (Retention, Quality, De-identification) | SI-12.1, SI-12.2, SI-12.3, SI-18, SI-18.4, SI-19 |
+| 4 | PII Limitation (Audit, Physical, Access, Boundary) | AU-3.3, PE-8.3, AC-3.14, SC-7.24 |
+| 3 | Training & Incident Response | AT-3.5, IR-2.3, IR-8.1 |
+| 2 | Planning & Engineering | PL-9, SA-8.33 |
+
+> **Note:** The implementation-level deltas table represents the initial scoping analysis. Additional controls may surface during full OSCAL baseline resolution.
 
 ## How an Auditor Uses This Output
 

--- a/analysis/gap-analysis.md
+++ b/analysis/gap-analysis.md
@@ -1039,3 +1039,164 @@ Typical disposal techniques:
 - **Log-retention tension.** AU-6 implementation-level delta requires 1-year minimum retention for CJI audit events; SI-12.3 requires disposal at retention end. The reconciliation: dispose at exactly 1 year plus any extension, not earlier (would violate AU-6) and not later (would violate SI-12.3 minimization principle).
 - **Backup retention alignment.** Backup systems often retain for years for DR purposes. A 7-day retention on an active database plus a 2-year retention on its nightly backup is an inconsistency — the backup retains what the active system has disposed. Align backup retention with the disposal schedule or document the deliberate offset and its legal/operational basis.
 - **Cloud provider snapshot copies.** Some cloud services retain snapshots or transit copies that the customer does not directly control (for example, AWS S3 versioning history, RDS automated backups). Understand the provider's data lifecycle and ensure provider disposal mechanisms align with SI-12.3, or contractually flow down the obligation to the provider.
+
+---
+
+### AU-3.3 — Limit Personally Identifiable Information Elements (Audit Records)
+
+**NIST 800-53 Rev 5 Control:** Limit personally identifiable information contained in audit records to the following elements identified in the privacy risk assessment: [organization-defined elements].
+
+**CJIS v6.0 Reference:** PII-in-log minimization; intersects with AU-6 (implementation-level delta requiring weekly review and 1-year retention).
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High's AU-3 base control requires specific content in audit records (timestamp, event type, source, outcome, identity) but does not impose PII minimization within those records. FedRAMP audit records can therefore contain significant PII, bounded only by the AU-3 minimums and organizational practice.
+
+#### CJIS v6.0 Requirement
+
+Audit records must contain only the PII elements identified as necessary in the privacy risk assessment. The intent is that log contents themselves do not become a secondary privacy exposure. For CJI, audit logs typically need to record who queried what case, when, from where, and the action's outcome — not the full query response payload.
+
+#### Implementation Guidance
+
+1. **Conduct the privacy risk assessment for audit records.** RA-3 output defines which PII elements are permissible in logs. Typical permitted set: user identifier, action, object identifier (case ID, record ID), timestamp, source IP or host. Typical excluded set: full CJI payload, fingerprint template data, full criminal history return, photo data.
+2. **Separate identity from content.** Log the object ID, not the object content. The audit log says "user X accessed record Y at time T"; the content of record Y is not stored inline in the log. If content is needed for investigation, reconstruct via the record ID against the primary data store.
+3. **Sanitize at the logging layer.** Application code that writes audit records should construct log payloads from the permitted-elements list explicitly, not dump the full request/response object. Implicit logging (Python `logger.info(request)` with a full PII-bearing object) is a common source of leakage.
+4. **Apply to aggregated and exported logs.** If audit data is exported to a SIEM or central logging platform, the minimization applies to those copies too. Masking or transformation before export is preferable to retroactive redaction.
+5. **Reconcile with AU-6 retention.** CJIS requires 1-year minimum retention for CJI audit events. Minimized logs are still subject to this. The interplay: minimize content, preserve necessary elements, retain for the full period.
+
+#### Evidence Required
+
+- **Privacy risk assessment output** (RA-3) defining permitted audit record elements for AU-3.3 parameter (au-03.03_odp).
+- **Audit record schema** documenting the permitted element set.
+- **Sample audit records** showing permitted elements only; no full CJI payloads.
+- **SIEM or central logging configuration** demonstrating minimization in exported copies.
+- **Code review or logging library standards** showing sanitization at the logging boundary.
+
+#### Key Considerations
+
+- **Tension with thorough audit.** A responder investigating a suspicious access may want the full query payload, not just the object ID. Design the logging architecture to support just-in-time retrieval of the content via the object ID rather than preserving it inline. This preserves investigative capability without inflating the audit log's privacy risk.
+- **Log volume and retention cost.** Paradoxically, minimization reduces storage costs and eases 1-year retention compliance (AU-6 implementation-level delta) since logs are smaller.
+- **Propagation into SIEM.** If CJI-minimized logs feed a SIEM, the SIEM's privacy posture inherits the minimization. If the SIEM enriches with additional context (geolocation, user profile), those enrichments must not reintroduce excluded PII.
+
+---
+
+### PE-8.3 — Limit Personally Identifiable Information Elements (Visitor Access Records)
+
+**NIST 800-53 Rev 5 Control:** Limit personally identifiable information contained in visitor access records to the following elements identified in the privacy risk assessment: [organization-defined elements].
+
+**CJIS v6.0 Reference:** PII-in-visitor-log minimization; applies to facilities where CJI is stored or processed.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High's PE-8 base control requires visitor access records to be maintained for a defined period, with defined content (name, purpose of visit, name of escort, date/time). FedRAMP does not require minimizing PII within those records beyond the baseline content.
+
+#### CJIS v6.0 Requirement
+
+Visitor access records for facilities hosting CJI must contain only the PII elements identified in the privacy risk assessment as operationally necessary. Excess identifiers (for example, SSN, DOB, full driver's license number) must not be collected or retained in visitor logs if they are not required for the access control purpose.
+
+#### Implementation Guidance
+
+1. **Define permitted visitor record elements via RA-3.** Typical permitted set: name, employer or agency affiliation, purpose of visit, escort, date/time of entry/exit. Typical excluded set: SSN, DOB, full driver's license number, photograph (unless operationally required for access control).
+2. **Update visitor management system configuration.** Many commercial visitor management systems capture by default more than is needed. Configure the system to collect only the permitted elements.
+3. **Physical logs (paper sign-in sheets) follow the same rule.** If the facility uses paper visitor logs, the form must not request excluded elements.
+4. **Align with retention and disposal.** Visitor records are subject to retention schedules. When they reach end-of-retention, apply SI-12.3 disposal techniques. Visitor records are a small but real surface for PII retention drift.
+5. **Communicate the collection rationale.** If visitors ask why specific elements are collected (or not collected), staff should be able to cite the privacy risk assessment rationale.
+
+#### Evidence Required
+
+- **Privacy risk assessment output** (RA-3) defining permitted visitor record elements for PE-8.3 parameter (pe-08.03_odp).
+- **Visitor management system configuration** or sign-in form showing the limited element set.
+- **Sample visitor records** demonstrating compliance.
+- **Retention and disposal documentation** for visitor logs.
+
+#### Key Considerations
+
+- **Escort visits to data centers hosting CJI.** Many cloud-hosted CJIS deployments involve CSP-operated data centers that rarely if ever have agency personnel on-site as visitors. PE-8.3 applies nonetheless to whatever visitor logs exist (for example, CSP-side maintenance vendor visits, agency audit visits, inspectors). The CSP's visitor logging practice is in scope.
+- **Agency-operated facilities (command centers, evidence rooms).** Agencies operating their own CJI-hosting facilities have a more direct PE-8.3 obligation. Visitor traffic is typically higher and the log scrutiny from CJIS auditors is more visible.
+- **Badge-reader logs versus sign-in logs.** Electronic access logs from badge readers typically do not contain PII beyond badge ID, which is not typically considered PII unless linked to the cardholder directly. Those are usually out of PE-8.3 scope, but the linkage table (badge ID to cardholder) that can re-link is in scope for other controls (AC-2, AC-3).
+
+---
+
+### AC-3.14 — Individual Access
+
+**NIST 800-53 Rev 5 Control:** Provide [organization-defined mechanisms] to enable individuals to have access to the following elements of their personally identifiable information: [organization-defined elements].
+
+**CJIS v6.0 Reference:** Subject access to own PII; law-enforcement records exemption recognized in supplemental guidance.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High does not require a subject-access mechanism. U.S. subject access rights are sector-specific (Privacy Act for federal agency records, HIPAA for health, GLBA for financial) and FedRAMP does not generalize them.
+
+#### CJIS v6.0 Requirement
+
+Provide a mechanism enabling individuals to access the organization-defined elements of their own PII. For CJI specifically, the NIST supplemental guidance explicitly recognizes that law enforcement records may be exempt from disclosure under Privacy Act section (j)(2) or state analogues. The control therefore operates as: provide the mechanism; apply the statutory exemptions when responding.
+
+The relationship with SI-18.4 (individual requests for correction/deletion):
+- **AC-3.14 = access** (I want to see what you have about me).
+- **SI-18.4 = correction/deletion** (I want you to fix or remove what you have).
+They are complementary controls; an individual typically exercises access first, then correction.
+
+#### Implementation Guidance
+
+1. **Define the access mechanism.** Typically coordinated with the state CSA. Forms, authentication requirements, fees (if any), response SLAs, and redaction policy should be documented. Exemptions must be pre-catalogued so the response can cite them.
+2. **Authenticate the requester.** Subject access requires strong identity verification — a requester is asking for another person's record if identity is not verified. Typical mechanisms: notarized request, in-person verification with government ID, or AAL2 electronic identity proofing (coordinates with IA-2 implementation-level delta which requires AAL2 for CJI access).
+3. **Route to privacy and legal for adjudication.** Senior agency official for privacy, legal counsel, and often the CJIS Systems Officer review the request. The adjudication determines what is released, what is redacted, what is withheld under exemption.
+4. **Respond with cited exemptions.** If elements are withheld, cite the exemption source (statute or regulation). A plain "no" without citation is non-compliant with typical Privacy Act practice.
+5. **Track the requests.** Volume, response time, approval/partial-approval/denial breakdown; metrics feed privacy program reporting.
+
+#### Evidence Required
+
+- **Documented access mechanism** (forms, authentication requirements, fees, SLA, redaction policy).
+- **Exemption register** cataloguing applicable statutory exemptions.
+- **Sample request records** showing the full workflow (intake, authentication, adjudication, response with citations).
+- **Aggregate metrics** for access requests received and resolved.
+
+#### Key Considerations
+
+- **Law-enforcement records exemption is broad, not absolute.** The Privacy Act (j)(2) exemption applies to maintained systems of records principally compiled for criminal law enforcement purposes. Not every CJI system qualifies; apply the exemption rigorously per statute, not reflexively.
+- **Partial disclosure is common.** Rather than full denial, many responses release non-sensitive elements (for example, arrest date and disposition category) while withholding investigative narrative, informant identity, or other sensitive elements. Partial disclosure requires a more complex redaction workflow.
+- **Identity proofing is the hard part.** Weak authentication at the request intake means someone can request another person's criminal history. Strong identity proofing is operationally burdensome but compliance-critical. Coordinate with IA-2 implementation-level delta's AAL2 guidance for online mechanisms.
+- **Chilling effect to avoid.** An overly burdensome access mechanism may effectively deny the right in practice. Reasonable authentication should not be confused with insurmountable authentication. Courts have found pretextual denial via impossible process to violate subject-access rights.
+
+---
+
+### SC-7.24 — Personally Identifiable Information at Boundaries
+
+**NIST 800-53 Rev 5 Control:** For systems that process personally identifiable information: apply the following processing rules to data elements of personally identifiable information: [organization-defined rules]; monitor for permitted processing at external interfaces and at key internal boundaries; document each processing exception; and review and remove exceptions that are no longer supported.
+
+**CJIS v6.0 Reference:** Boundary-processing rules for CJI; enforcement and monitoring at system interfaces.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High's SC-7 base control requires boundary protection (firewalls, DMZ architecture) but does not require PII-specific processing rules with exception tracking. FedRAMP's PII boundary posture is generic rather than PII-aware.
+
+#### CJIS v6.0 Requirement
+
+Systems processing CJI must:
+- Define processing rules per CJI data element (what operations are allowed: read, write, dissemination to specific destinations, transformation, retention).
+- Monitor for compliance at external interfaces (for example, API gateway for NCIC queries, state CJIS network interface) and at key internal boundaries (for example, between the CJIS application tier and a database tier, between primary and replica systems).
+- Document exceptions where processing deviates from the rules.
+- Periodically review the exception list and remove stale exceptions.
+
+#### Implementation Guidance
+
+1. **Define processing rules per CJI element class.** Example: "Driver's license numbers may be queried by dispatch; they must not be exported to non-dispatch systems; they must be masked in analytics outputs." Rules are organization-defined (sc-07.24_odp) and must be documented in the SSP.
+2. **Enforce at technical boundaries.** API gateways should be configured with per-element policy. Inter-tier communication should enforce rules (for example, a dispatch tier may not send raw fingerprint data to an analytics tier). This often requires policy-as-code approaches (for example, OPA/Rego at API gateways) that the CSP or agency can demonstrate.
+3. **Monitor at boundaries.** Instrument the boundary with telemetry that records processing attempts and rule evaluation outcomes. This becomes the evidence trail for audit.
+4. **Exception workflow.** When a processing rule must be deviated from (for example, a short-lived integration with a new system), document the exception: what rule, what scope, what compensating control, what expiration date. Exceptions without expiration drift into permanent policy violations.
+5. **Exception review cadence.** Organization-defined; typical quarterly review. Expired exceptions must be closed (either by aligning practice with the rule, extending the exception with justification, or ending the deviating practice).
+
+#### Evidence Required
+
+- **Processing rules documentation** per CJI element class (sc-07.24_odp parameter value).
+- **Boundary configuration** (API gateway policy, inter-tier enforcement rules).
+- **Monitoring telemetry** showing rule evaluation at boundaries.
+- **Exception register** listing each active exception with scope, compensating control, and expiration.
+- **Exception review records** documenting quarterly (or defined-frequency) reviews and closure of stale exceptions.
+
+#### Key Considerations
+
+- **Policy-as-code is the practical enforcement.** Ad-hoc "don't send PII across this boundary" is unenforceable at scale. OPA/Rego, API gateway policy engines, or service-mesh policy provide evaluable rules. This aligns with FedRAMP 20x compliance-as-code direction.
+- **Monitor volume can be very high.** Every CJI query is potentially a boundary evaluation. Sampling or aggregate telemetry may be necessary; full per-request logging may be prohibitive. Design the monitoring plan to balance evidentiary value with operational cost.
+- **Exception drift is the primary failure mode.** Exceptions created for good reasons become permanent in practice because no one reviews. The review cadence is the control's backstop. Without it, SC-7.24 becomes a policy that everyone exempts in practice.
+- **Ties to SI-12.1 (limit PII elements).** SI-12.1 defines what elements are in-scope; SC-7.24 enforces processing rules on those elements at boundaries. The two controls compose: SI-12.1 is the minimization principle, SC-7.24 is the enforcement mechanism at system edges.

--- a/analysis/gap-analysis.md
+++ b/analysis/gap-analysis.md
@@ -2,23 +2,52 @@
 
 Source data: `data/cjis-overlay.json` (OSCAL overlay with structured delta capture)
 
-## Delta Controls
+## Gap Categories
 
-| Control | Category | Status |
-|---------|----------|--------|
-| AC-2 | Access Control | Complete |
-| AT-2 | Training | Complete |
-| AU-6 | Audit | Complete |
-| IA-2 | Authentication | Complete |
-| IA-5 | Authentication | Complete |
-| IR-6 | Incident Response | Complete |
-| MP-6 | Media Protection | Complete |
-| PE-17 | Physical/Environmental | Complete |
-| PS-3 | Personnel | Complete |
-| PS-6 | Personnel | Complete |
+The gap analysis distinguishes two categories of gaps between CJIS v6.0 and FedRAMP High:
+
+1. **Implementation-level deltas** are controls present in both baselines where CJIS imposes stricter parameters, scope, or methodology. The baseline control exists in FedRAMP High; CJIS tightens it (for example, CJIS requires fingerprint-based background checks for PS-3 while FedRAMP leaves screening method to organizational discretion).
+2. **Control-level gaps** are controls present in the CJIS v6.0 baseline but absent from FedRAMP High entirely. An agency running FedRAMP High must implement these from scratch to satisfy CJIS. These are concentrated in the NIST 800-53 Rev 5 privacy overlay, reflecting CJI's status as sensitive personal data.
+
+Baseline comparison identifies 13 implementation-level deltas and 15 control-level gaps. The analysis below addresses both, grouped by category.
+
+### Implementation-Level Deltas (13 controls)
+
+| Control | Family | Status |
+|---------|--------|--------|
+| PS-3 | Personnel Security | Complete |
+| PS-6 | Personnel Security | Complete |
+| IA-2 | Identification and Authentication | Complete |
+| IA-5 | Identification and Authentication | Complete |
 | SC-12 | Encryption | Complete |
 | SC-13 | Encryption | Complete |
 | SC-28 | Encryption | Complete |
+| MP-6 | Media Protection | Complete |
+| AU-6 | Audit and Accountability | Complete |
+| AC-2 | Access Control | Complete |
+| IR-6 | Incident Response | Complete |
+| PE-17 | Physical and Environmental Protection | Complete |
+| AT-2 | Awareness and Training | Complete |
+
+### Control-Level Gaps (15 controls)
+
+| Control | Family | Cluster | Status |
+|---------|--------|---------|--------|
+| SI-12.1 | System and Information Integrity | Privacy, Retention | Pending |
+| SI-12.2 | System and Information Integrity | Privacy, Retention | Pending |
+| SI-12.3 | System and Information Integrity | Privacy, Retention | Pending |
+| SI-18 | System and Information Integrity | Privacy, Quality | Pending |
+| SI-18.4 | System and Information Integrity | Privacy, Quality | Pending |
+| SI-19 | System and Information Integrity | Privacy, De-identification | Pending |
+| AU-3.3 | Audit and Accountability | PII Limitation | Pending |
+| PE-8.3 | Physical and Environmental Protection | PII Limitation | Pending |
+| AC-3.14 | Access Control | PII Limitation | Pending |
+| SC-7.24 | System and Communications Protection | PII Limitation | Pending |
+| AT-3.5 | Awareness and Training | Training | Pending |
+| IR-2.3 | Incident Response | Training | Pending |
+| IR-8.1 | Incident Response | Incident Response Planning | Pending |
+| PL-9 | Planning | Central Management | Pending |
+| SA-8.33 | System and Services Acquisition | Engineering | Pending |
 
 ---
 
@@ -860,3 +889,21 @@ An auditor will expect to see:
 - **Role-specific training considerations.** CJIS training requirements apply to all personnel with CJI access, but the level of detail may vary by role. A sworn officer querying NCIC needs different emphasis than a database administrator with logical access to CJI at rest. Consider role-based training tracks within the CJIS training program, with shared core content on dissemination rules, Security Addendum, and sanctions, and role-specific content on handling CJI in the user's operational context.
 - **Phishing simulation integration.** If the organization conducts phishing simulations as part of awareness techniques (at-02_odp.05), ensure the simulations include CJI-relevant scenarios (e.g., fake credentials prompts for CJI systems, fake communications purporting to be from the CJIS Systems Officer). Generic phishing simulations do not reflect the threat landscape for law enforcement users.
 - **Content versioning.** CJIS Security Policy has evolved (v5.x to v6.0 was a significant update with alignment to NIST 800-53 Rev 5). Training content must be versioned and updated when policy changes. An organization delivering 2026 training with 2022-era content has not satisfied the content update requirement (at-02_odp.06).
+
+---
+
+## Control-Level Gaps
+
+This section documents controls present in the CJIS v6.0 baseline but absent from the FedRAMP High baseline. Unlike the implementation-level deltas above, where the control exists in both baselines and CJIS imposes stricter parameters, these are entirely new controls a FedRAMP High environment must implement to satisfy CJIS.
+
+Control-level gaps were identified by OSCAL baseline comparison between the CJIS v6.0 baseline (302 controls) and the FedRAMP High baseline (410 controls). Of the 302 CJIS controls, 287 overlap with FedRAMP High and 15 do not. The 15 gap controls cluster around NIST 800-53 Rev 5 privacy requirements, reflecting CJI's classification as sensitive personal data that FedRAMP High does not explicitly address at the privacy-overlay level.
+
+Documentation for each control (baseline text, CJIS relevance, implementation guidance, evidence required) is being added across subsequent releases, grouped by cluster:
+
+- **Privacy, Retention** (SI-12.1, SI-12.2, SI-12.3): CJI retention limits, minimization in testing/training/research, disposal procedures.
+- **Privacy, Quality and De-identification** (SI-18, SI-18.4, SI-19): PII quality operations for CJI, individual access requests, de-identification.
+- **PII Limitation** (AU-3.3, PE-8.3, AC-3.14, SC-7.24): Limiting PII elements in audit records, visitor access records, individual access enforcement, and boundary protection.
+- **Training and Incident Response** (AT-3.5, IR-2.3, IR-8.1): Role-based training on PII/CJI processing, breach-specific IR training, breach response plan.
+- **Planning and Engineering** (PL-9, SA-8.33): Central management of security and privacy controls, minimization as an engineering principle.
+
+OSCAL data for each control is captured in `data/cjis-overlay.json` with the `gap-type` property set to `control-level-gap` (distinguishing them from implementation-level deltas, which carry `gap-type: implementation-delta`).

--- a/analysis/gap-analysis.md
+++ b/analysis/gap-analysis.md
@@ -907,3 +907,135 @@ Documentation for each control (baseline text, CJIS relevance, implementation gu
 - **Planning and Engineering** (PL-9, SA-8.33): Central management of security and privacy controls, minimization as an engineering principle.
 
 OSCAL data for each control is captured in `data/cjis-overlay.json` with the `gap-type` property set to `control-level-gap` (distinguishing them from implementation-level deltas, which carry `gap-type: implementation-delta`).
+
+---
+
+### SI-12.1 — Limit Personally Identifiable Information Elements
+
+**NIST 800-53 Rev 5 Control:** Limit personally identifiable information being processed in the information life cycle to the following elements of personally identifiable information: [organization-defined elements of PII].
+
+**CJIS v6.0 Reference:** Information Management privacy overlay; applies to CJI as a class of sensitive PII.
+
+#### FedRAMP High Baseline Requirement
+
+Not included at this enhancement level. FedRAMP High includes the SI-12 base control (information management and retention, satisfied via NARA records retention schedules and organizational procedures) but does not include the privacy enhancement SI-12.1. FedRAMP High addresses PII through access controls (AC family), security and privacy attributes (AC-16), and physical access (PE-2) rather than by imposing a lifecycle-wide PII minimization requirement.
+
+#### CJIS v6.0 Requirement
+
+Controls must actively limit the PII elements processed across the CJI information lifecycle (creation, collection, use, processing, storage, maintenance, dissemination, disclosure, disposition) to an organization-defined list. The requirement is data minimization: only process PII elements required for operational purposes; exclude elements not operationally needed even when they are technically available.
+
+CJI qualifies as PII because it includes direct identifiers (name, date of birth, SSN, biometrics) and criminal history data tied to identifiable individuals. CJIS v6.0 imports SI-12.1 to apply the minimization principle to CJI.
+
+#### Implementation Guidance
+
+1. **Enumerate CJI data elements.** Distinguish mandatory operational elements (for example, the NCIC query payload fields needed for a hit/miss response) from optional elements that upstream APIs return by default (photos, address history, secondary identifiers in a bundle).
+2. **Define the allowed-elements list.** Document which specific CJI data elements the system processes at each lifecycle stage. Capture this in the SSP and system design. Elements not on the list must not be stored or processed even if the upstream API returns them.
+3. **Enforce at ingest.** Filter incoming CJI payloads at the API gateway or ingest layer to strip unneeded elements before storage. Display-layer filtering is not sufficient since persisted-but-not-shown elements are still "processed" within the meaning of SI-12.1.
+4. **Enforce at disclosure.** When CJI is returned to users or downstream systems, include only the allowed elements for the disclosure context. A fingerprint-based identity verification response does not need to include a full criminal history unless the operational purpose requires it.
+5. **Review the allowed-elements list.** Review annually or when system boundaries change. Operational needs shift as workflows and integrations evolve.
+
+#### Evidence Required
+
+- **CJI data element inventory** listing elements processed at each lifecycle stage.
+- **Design/architecture documents** showing where element filtering occurs (API gateway, database ingest, dissemination layer).
+- **Sample records** or log extracts demonstrating excluded elements are not persisted.
+- **Review records** showing periodic re-evaluation of the allowed-elements list.
+- **Risk assessment output** informing which elements are in-scope versus out-of-scope under SI-12.1's organization-defined parameter (si-12.01_odp).
+
+#### Key Considerations
+
+- **Bulk-return API design.** Many NCIC and state CJIS query APIs return bundled records in a single response. SI-12.1 compliance requires filtering the bundle to only the elements needed by the requesting workflow, not passing the bundle through wholesale.
+- **PII-in-log is silent retention.** Application logs and audit logs often capture PII elements unintentionally. Apply the minimization principle to log contents. This interacts with AU-3.3 (limit PII elements in audit records), another control-level gap in this analysis.
+- **Secondary copies.** Minimization scope includes backups, DR copies, caches, and ephemeral working data. A system can satisfy minimization in production and violate it in backup snapshots. Include all data copies in the enforcement scope.
+- **Field-level encryption is not minimization.** Encrypting an element still counts as processing it. Encryption is a layered protection, not a substitute for minimization. Decide first whether the element is needed; if yes, then apply encryption (see SC-28 implementation-level delta).
+- **Parameter definition required.** SI-12.1 has an organization-defined parameter (si-12.01_odp). Blank parameters are an audit finding. The CSP or agency must define the in-scope element set explicitly.
+
+---
+
+### SI-12.2 — Minimize Personally Identifiable Information in Testing, Training, and Research
+
+**NIST 800-53 Rev 5 Control:** Use the following techniques to minimize the use of personally identifiable information for research, testing, or training: [organization-defined techniques].
+
+**CJIS v6.0 Reference:** Information Management privacy overlay; applies to CJI in non-production contexts.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High includes general development safeguards (CM-4 security impact analysis, SA-3 system development life cycle) but does not require PII minimization in test, training, or research environments. Production data in test environments is a common anti-pattern that is not explicitly prohibited by FedRAMP alone.
+
+#### CJIS v6.0 Requirement
+
+Apply defined techniques to minimize PII use in non-production contexts (research, testing, training). The control recognizes that these contexts typically do not require real production PII to fulfill their purpose, and that using real PII in them multiplies exposure surface area (developer laptops, training rooms, research outputs, shared test environments).
+
+Techniques in scope:
+- **De-identification** (see SI-19): transforming records so the individual is no longer identifiable.
+- **Synthetic data**: machine-generated records that mimic production structure without containing real values.
+- **Data masking or tokenization**: replacing sensitive elements with placeholders while preserving format for shape-dependent testing.
+- **Subset sampling with legal basis**: rare; requires explicit authorization and typically additional controls.
+
+#### Implementation Guidance
+
+1. **Default to synthetic CJI in non-production.** Build a reference synthetic dataset with realistic structure (names, DOB, case IDs) that test systems can use for integration testing, UAT, performance testing, and training.
+2. **Prohibit production CJI in dev/test.** Policy plus technical enforcement: block export operations from production, require explicit approval gating, segregate network paths so production-to-non-production data flows are observable and restrictable.
+3. **Mask when real data is unavoidable.** Certain performance tests require near-production volume or data distribution that synthetic generation cannot reproduce. In those cases, mask direct identifiers (name, SSN, fingerprint templates, photos) and the identifying link columns. Unmasked CJI in test is a finding regardless of intent.
+4. **Train with scenarios, not case files.** CJIS system training should use synthetic case scenarios. Pulling a real historical case as training material (even an old closed case) is a minimization violation.
+5. **Governance for research use.** If the CSP or agency conducts research on CJI workflows (effectiveness studies, usability testing), require IRB-equivalent review and de-identification before research use.
+
+#### Evidence Required
+
+- **Synthetic dataset documentation** describing the generation method and coverage of test scenarios.
+- **Policy prohibiting production CJI in non-production environments.**
+- **Technical controls** enforcing the policy (database export restrictions, network segregation, audit logs of cross-environment data transfers).
+- **Training material samples** showing synthetic rather than real case data.
+- **Research governance records** if applicable (IRB-equivalent review output, de-identification method documentation, research dataset retention records).
+
+#### Key Considerations
+
+- **Minimization is a technique selection, not a binary.** The control requires defining techniques; the CSP chooses which apply to which context. Synthetic-data-only is the strongest posture. Masking is weaker because re-identification may be possible with auxiliary information. Document the technique per context.
+- **Interacts with SI-19 (de-identification).** De-identification techniques used to satisfy SI-12.2 should be consistent with the SI-19 requirements documented below.
+- **Training environments are often overlooked.** Agencies running CJIS training often use a stripped-down copy of production. Stripped-down is not minimized unless direct identifiers are removed by an explicit technique.
+- **CSP dev/test boundary.** If the CSP runs dev/test environments on behalf of agencies, the CSP inherits the SI-12.2 obligation. Ensure customer CJI does not flow into CSP dev/test and that vendor-side test data is synthetic or masked.
+
+---
+
+### SI-12.3 — Information Disposal
+
+**NIST 800-53 Rev 5 Control:** Use the following techniques to dispose of, destroy, or erase information following the retention period: [organization-defined techniques].
+
+**CJIS v6.0 Reference:** Information Management privacy overlay; disposal of CJI and CJI-bearing artifacts (logs, backups, archives).
+
+#### FedRAMP High Baseline Requirement
+
+Not included at the disposal-enhancement level. FedRAMP High includes MP-6 (media sanitization) for physical media disposal and SC-28 (protection of information at rest) for storage encryption. Neither imposes an explicit logical information disposal mandate — the active erasure or cryptographic destruction of information records when the retention period expires. FedRAMP's SI-12 base control treats retention generally without specifying how disposal executes at end-of-retention.
+
+#### CJIS v6.0 Requirement
+
+Use defined techniques to dispose of, destroy, or erase information at the end of the retention period. Scope includes originals, copies, archived records, and system logs that may contain PII or CJI. Disposal must be an active, scheduled, and evidentiable process rather than an informal "we delete when we clean up."
+
+Typical disposal techniques:
+- **Logical erasure** with verified overwrite (secure delete utilities, database TRUNCATE plus vacuum, file-system zero-fill).
+- **Cryptographic erasure** (destruction of the encryption key rendering the ciphertext permanently unrecoverable; the practical disposal technique for cloud-hosted archives where physical destruction is impossible).
+- **Physical destruction** for end-of-life media (satisfied by MP-6 implementation-level delta procedures).
+
+#### Implementation Guidance
+
+1. **Define retention periods per CJI data class.** Document retention for each CJI category (active-case records, closed-case archives, audit logs, incident records, backup copies). Without explicit periods, "end of retention" is undefined and disposal cannot be triggered on schedule.
+2. **Select disposal technique per data class.** Logical erasure for active-system records, cryptographic erasure for cloud-hosted archives, physical destruction for end-of-life hardware. Document the mapping.
+3. **Automate disposal where possible.** Scheduled disposal jobs (for example, AWS S3 Lifecycle policies that transition and then delete after N days) reduce the risk of retained-past-period records. Manual-only disposal scales poorly and frequently misses archive copies.
+4. **Include logs, backups, caches.** Disposal applies to all copies of the record, including audit logs that captured CJI (intersects with AU-3.3), database replicas, backup snapshots, DR copies, and ephemeral caches. A record disposed in the primary database but preserved in a nightly backup is not disposed within SI-12.3's meaning.
+5. **Produce disposal evidence.** Logs showing the disposal event (what was disposed, when, by which technique). Without evidence, disposal cannot be asserted at audit.
+
+#### Evidence Required
+
+- **Retention schedule** per CJI data class.
+- **Disposal procedures** documenting the technique applied per class.
+- **Disposal logs and reports** showing execution — lifecycle policy run reports, secure-delete verification output, key-destruction records for cryptographic erasure.
+- **Cross-copy coverage evidence** — documentation that backups, DR copies, and log archives are included in the disposal scope and schedule, not excluded by omission.
+- **Media destruction certificates** for physical disposal events (coordinates with MP-6).
+
+#### Key Considerations
+
+- **Cryptographic erasure in cloud environments.** Destroying an AWS KMS customer-managed CMK renders ciphertext in S3, EBS, or RDS permanently unrecoverable. This is often the only practical erasure mechanism for cloud-hosted archives where physical media destruction is not possible. Requires key hierarchy design (see SC-12 implementation-level delta) that supports targeted key destruction without collateral data loss.
+- **Legal holds override disposal.** Records under litigation hold must not be disposed even when the retention period expires. Integrate legal-hold awareness into the disposal automation; a blind lifecycle policy that deletes on schedule regardless of hold status is non-compliant.
+- **Log-retention tension.** AU-6 implementation-level delta requires 1-year minimum retention for CJI audit events; SI-12.3 requires disposal at retention end. The reconciliation: dispose at exactly 1 year plus any extension, not earlier (would violate AU-6) and not later (would violate SI-12.3 minimization principle).
+- **Backup retention alignment.** Backup systems often retain for years for DR purposes. A 7-day retention on an active database plus a 2-year retention on its nightly backup is an inconsistency — the backup retains what the active system has disposed. Align backup retention with the disposal schedule or document the deliberate offset and its legal/operational basis.
+- **Cloud provider snapshot copies.** Some cloud services retain snapshots or transit copies that the customer does not directly control (for example, AWS S3 versioning history, RDS automated backups). Understand the provider's data lifecycle and ensure provider disposal mechanisms align with SI-12.3, or contractually flow down the obligation to the provider.

--- a/data/cjis-overlay.json
+++ b/data/cjis-overlay.json
@@ -781,6 +781,194 @@
               ]
             }
           ]
+        },
+        {
+          "control-id": "au-3.3",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "au_3_3_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Limit PII Elements in Audit Records",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "au_3_3_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP's AU-3 requires specific audit record content (timestamp, event type, source, outcome, identity) but does not impose PII minimization within audit records."
+                    },
+                    {
+                      "id": "au_3_3_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Audit records must contain only the PII elements identified as necessary in the privacy risk assessment (RA-3). Intent is that log contents themselves do not become a secondary PII exposure. For CJI, typically log the action metadata (who, when, what object, from where) without embedding the full CJI payload."
+                    },
+                    {
+                      "id": "au_3_3_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Conduct RA-3 privacy risk assessment to define permitted audit record elements. Log object identifiers (case ID, record ID) rather than object content. Sanitize at the logging layer so implicit logging (dumping full request/response objects) does not leak PII. Apply minimization to exported log copies (SIEM, central log platform). Reconcile with AU-6 implementation-level delta (1-year retention) so minimized logs still meet retention obligations."
+                    },
+                    {
+                      "id": "au_3_3_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Privacy risk assessment output defining permitted audit record elements; audit record schema documenting the permitted element set; sample audit records showing permitted elements only; SIEM configuration demonstrating minimization in exported copies; logging library standards or code review documentation."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "pe-8.3",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "pe_8_3_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Limit PII Elements in Visitor Access Records",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "pe_8_3_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP's PE-8 requires visitor access records be maintained with defined content (name, purpose, escort, date/time) but does not require minimizing PII within those records."
+                    },
+                    {
+                      "id": "pe_8_3_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Visitor access records for facilities hosting CJI must contain only the PII elements identified in the privacy risk assessment as operationally necessary. Excess identifiers (SSN, DOB, full driver's license, photograph) must not be collected if not required for access control."
+                    },
+                    {
+                      "id": "pe_8_3_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define permitted visitor record elements via RA-3. Configure visitor management systems (and paper sign-in forms) to collect only permitted elements. Align with retention and SI-12.3 disposal schedules. Communicate the collection rationale to visitors who ask."
+                    },
+                    {
+                      "id": "pe_8_3_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Privacy risk assessment output defining permitted visitor record elements; visitor management system configuration or sign-in form showing limited element set; sample visitor records demonstrating compliance; retention and disposal documentation for visitor logs."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "ac-3.14",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "ac_3_14_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Individual Access to PII",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "ac_3_14_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP does not require a subject-access mechanism. U.S. subject access rights are sector-specific (Privacy Act, HIPAA, GLBA)."
+                    },
+                    {
+                      "id": "ac_3_14_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Provide a mechanism enabling individuals to access their own PII elements as defined. NIST supplemental guidance recognizes law-enforcement records may be exempt from disclosure under Privacy Act (j)(2) or state analogues; the control operates as: provide the mechanism, apply statutory exemptions when responding."
+                    },
+                    {
+                      "id": "ac_3_14_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define the access mechanism (forms, authentication, fees, SLA, redaction policy) coordinated with the state CSA. Authenticate requesters strongly (notarized request, in-person ID verification, or AAL2 electronic identity proofing per IA-2). Route to privacy official and legal counsel for adjudication. Respond with cited exemptions for withheld elements. Track request volume, response time, and approval breakdown."
+                    },
+                    {
+                      "id": "ac_3_14_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Documented access mechanism (forms, authentication, SLA, redaction policy); exemption register cataloguing applicable statutory exemptions; sample request records showing full workflow from intake through response; aggregate metrics for access requests received and resolved."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "sc-7.24",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "sc_7_24_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — PII Processing Rules at Boundaries",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "sc_7_24_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP's SC-7 requires boundary protection (firewalls, DMZ) but not PII-specific processing rules with exception tracking."
+                    },
+                    {
+                      "id": "sc_7_24_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "For systems processing CJI: define processing rules per PII element (what operations are allowed), monitor for permitted processing at external interfaces and internal boundaries, document each exception, and periodically review and remove stale exceptions."
+                    },
+                    {
+                      "id": "sc_7_24_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define processing rules per CJI element class in the SSP (sc-07.24_odp parameter). Enforce at technical boundaries (API gateways, inter-tier controls) using policy-as-code where feasible (OPA/Rego, API gateway policies). Instrument boundaries with telemetry to record rule evaluations. Maintain an exception register with scope, compensating control, and expiration. Review exceptions on a defined cadence (typical quarterly) and close stale exceptions."
+                    },
+                    {
+                      "id": "sc_7_24_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Processing rules documentation per CJI element class; boundary configuration (API gateway policy, inter-tier enforcement rules); monitoring telemetry showing rule evaluations; exception register listing active exceptions with scope and expiration; exception review records showing closure of stale exceptions."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/data/cjis-overlay.json
+++ b/data/cjis-overlay.json
@@ -640,6 +640,147 @@
               ]
             }
           ]
+        },
+        {
+          "control-id": "si-12.1",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "si_12_1_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Limit PII Elements",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "privacy-retention"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "si_12_1_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP includes SI-12 base (information retention generally) but not the privacy enhancement SI-12.1 that requires active minimization of PII elements across the information lifecycle."
+                    },
+                    {
+                      "id": "si_12_1_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Limit the PII elements processed during the CJI information lifecycle (creation, collection, use, processing, storage, maintenance, dissemination, disclosure, disposition) to an organization-defined list of elements. Elements not needed for operational purposes must be excluded from processing even if they are technically available from upstream APIs."
+                    },
+                    {
+                      "id": "si_12_1_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Enumerate the CJI data elements the system processes at each lifecycle stage. Define and document the allowed-elements list in the SSP. Enforce minimization at ingest by filtering incoming payloads to strip unneeded elements before storage. Enforce at disclosure by returning only elements required for the disclosure context. Review the allowed-elements list annually or on system boundary changes. Include backups, DR copies, caches, and logs in the enforcement scope."
+                    },
+                    {
+                      "id": "si_12_1_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "CJI data element inventory per lifecycle stage; design/architecture documents showing where element filtering occurs; sample records or log extracts demonstrating excluded elements are not persisted; review records showing periodic re-evaluation of the allowed-elements list; documented organization-defined parameter value for si-12.01_odp."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "si-12.2",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "si_12_2_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Minimize PII in Testing, Training, and Research",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "privacy-retention"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "si_12_2_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP addresses development safeguards (CM-4, SA-3) but does not require minimization of PII in non-production environments. Production data in test environments is a common anti-pattern not explicitly prohibited by FedRAMP."
+                    },
+                    {
+                      "id": "si_12_2_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Apply defined techniques (de-identification, synthetic data, data masking, tokenization) to minimize the use of CJI and PII in research, testing, and training contexts. Real CJI in non-production environments is prohibited unless minimized by an explicit technique."
+                    },
+                    {
+                      "id": "si_12_2_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Default to synthetic CJI in non-production environments. Build a reference synthetic dataset with realistic structure. Prohibit production CJI in dev/test by policy and technical enforcement (export restrictions, network segregation, approval gating). Mask direct identifiers when real data shape is required for testing. Use synthetic case scenarios for training rather than real case files. For research use, require IRB-equivalent review and de-identification."
+                    },
+                    {
+                      "id": "si_12_2_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Synthetic dataset documentation; policy prohibiting production CJI in non-production environments; technical controls enforcing the policy (database export restrictions, network segregation, cross-environment transfer audit logs); training material samples showing synthetic data; research governance records including de-identification method documentation."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "si-12.3",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "si_12_3_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Information Disposal",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "privacy-retention"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "si_12_3_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included at the disposal-enhancement level in FedRAMP High baseline. FedRAMP includes MP-6 (media sanitization) for physical media and SC-28 (protection at rest) for storage encryption, but not the logical information disposal mandate that requires active erasure or cryptographic destruction at end of retention."
+                    },
+                    {
+                      "id": "si_12_3_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Use defined techniques (logical erasure with verified overwrite, cryptographic erasure via key destruction, physical destruction) to dispose of, destroy, or erase CJI and CJI-bearing artifacts at the end of the retention period. Scope includes originals, copies, archived records, and system logs that may contain PII or CJI. Disposal must be scheduled and produce audit evidence."
+                    },
+                    {
+                      "id": "si_12_3_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define retention periods per CJI data class in the SSP. Select the disposal technique per class (logical erasure for active records, cryptographic erasure for cloud archives via KMS key destruction, physical destruction for end-of-life media). Automate disposal where possible (AWS S3 Lifecycle policies). Include logs, backups, DR copies, and caches in the disposal scope. Integrate legal-hold awareness so held records are not disposed on schedule. Produce disposal logs showing what was disposed, when, and by which technique."
+                    },
+                    {
+                      "id": "si_12_3_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Retention schedule per CJI data class; disposal procedures per class; disposal logs (lifecycle policy run reports, secure-delete verification output, key-destruction records); cross-copy coverage documentation showing backups and log archives are in scope; media destruction certificates for physical disposal events; legal-hold workflow documentation."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/data/cjis-overlay.json
+++ b/data/cjis-overlay.json
@@ -6,7 +6,7 @@
       "last-modified": "2026-04-01T00:00:00Z",
       "version": "1.0.0",
       "oscal-version": "1.1.2",
-      "remarks": "OSCAL overlay capturing controls where CJIS Security Policy v6.0 (December 2024) imposes requirements beyond the FedRAMP High baseline. CJIS v6.0 aligns with NIST 800-53 Rev 5 and becomes the audit standard April 1, 2026. Each delta control includes four structured parts: baseline-requirement, cjis-addition, implementation-guidance, and evidence-required.",
+      "remarks": "OSCAL overlay capturing controls where CJIS Security Policy v6.0 (December 2024) imposes requirements beyond the FedRAMP High baseline. CJIS v6.0 aligns with NIST 800-53 Rev 5 and becomes the audit standard April 1, 2026. Each cjis-delta part includes four structured sub-parts: baseline-requirement, cjis-addition, implementation-guidance, and evidence-required. Each cjis-delta part carries a gap-type prop with one of two values: implementation-delta (control present in both baselines; CJIS imposes stricter parameters, scope, or methodology) or control-level-gap (control present in CJIS v6.0 but absent from FedRAMP High; represents a net-new control for FedRAMP-authorized environments seeking CJIS compliance). A delta-category prop further groups controls by topical cluster (personnel, authentication, encryption, privacy-retention, pii-limitation, etc.).",
       "props": [
         {
           "name": "cjis-version",
@@ -44,6 +44,10 @@
                     {
                       "name": "delta-category",
                       "value": "personnel"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -87,6 +91,10 @@
                     {
                       "name": "delta-category",
                       "value": "personnel"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -130,6 +138,10 @@
                     {
                       "name": "delta-category",
                       "value": "authentication"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -173,6 +185,10 @@
                     {
                       "name": "delta-category",
                       "value": "authentication"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -216,6 +232,10 @@
                     {
                       "name": "delta-category",
                       "value": "media-protection"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -259,6 +279,10 @@
                     {
                       "name": "delta-category",
                       "value": "encryption"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -302,6 +326,10 @@
                     {
                       "name": "delta-category",
                       "value": "encryption"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -345,6 +373,10 @@
                     {
                       "name": "delta-category",
                       "value": "encryption"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -388,6 +420,10 @@
                     {
                       "name": "delta-category",
                       "value": "audit"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -431,6 +467,10 @@
                     {
                       "name": "delta-category",
                       "value": "access-control"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -474,6 +514,10 @@
                     {
                       "name": "delta-category",
                       "value": "incident-response"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -517,6 +561,10 @@
                     {
                       "name": "delta-category",
                       "value": "physical-environmental"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [
@@ -560,6 +608,10 @@
                     {
                       "name": "delta-category",
                       "value": "training"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "implementation-delta"
                     }
                   ],
                   "parts": [


### PR DESCRIPTION
## Summary

Documents the 4 PII-limitation controls that CJIS v6.0 imports from NIST 800-53 Rev 5 privacy overlay but FedRAMP High does not include. These controls share a pattern: limit PII exposure in a specific context (audit logs, visitor logs, individual access channel, boundary processing).

- **AU-3.3** — Limit PII Elements in Audit Records: log object IDs, not object content; reconcile with AU-6 implementation-level delta 1-year retention.
- **PE-8.3** — Limit PII Elements in Visitor Access Records: visitor management system configuration, aligned with SI-12.3 disposal.
- **AC-3.14** — Individual Access: subject access mechanism with law-enforcement exemption handling under Privacy Act (j)(2) or state analogues.
- **SC-7.24** — PII Processing Rules at Boundaries: policy-as-code enforcement, monitoring telemetry, exception register with review cadence.

Adds 4 new sections to `analysis/gap-analysis.md` under the `## Control-Level Gaps` H2 and 4 new alter entries to `data/cjis-overlay.json` with `gap-type: control-level-gap` and `delta-category: pii-limitation`.

## Controls Addressed

- AU-3.3 Limit Personally Identifiable Information Elements (Audit Records)
- PE-8.3 Limit Personally Identifiable Information Elements (Visitor Access Records)
- AC-3.14 Individual Access
- SC-7.24 Personally Identifiable Information (Boundary Processing)

## Test Plan

- [ ] JSON parses without error
- [ ] All 4 new alters have `gap-type: control-level-gap` and `delta-category: pii-limitation`
- [ ] Each alter has 4 sub-parts
- [ ] Gap-analysis.md renders correctly with new H3 sections
- [ ] AU-3.3 cross-reference to AU-6 implementation-level delta (1-year retention) is accurate
- [ ] AC-3.14 interaction with SI-18.4 (correction/deletion) is accurate
- [ ] SC-7.24 policy-as-code reference aligns with FedRAMP 20x direction

## Base branch

Stacked on `feat/gap-controls-privacy-quality` (PR #24). Switch base to `main` and rebase after upstream merges.

Part of #18