### PR TITLE
feat: document PII limitation control-level gaps

### DIFF
--- a/analysis/gap-analysis.md
+++ b/analysis/gap-analysis.md
@@ -1039,3 +1039,164 @@ Typical disposal techniques:
 - **Log-retention tension.** AU-6 implementation-level delta requires 1-year minimum retention for CJI audit events; SI-12.3 requires disposal at retention end. The reconciliation: dispose at exactly 1 year plus any extension, not earlier (would violate AU-6) and not later (would violate SI-12.3 minimization principle).
 - **Backup retention alignment.** Backup systems often retain for years for DR purposes. A 7-day retention on an active database plus a 2-year retention on its nightly backup is an inconsistency — the backup retains what the active system has disposed. Align backup retention with the disposal schedule or document the deliberate offset and its legal/operational basis.
 - **Cloud provider snapshot copies.** Some cloud services retain snapshots or transit copies that the customer does not directly control (for example, AWS S3 versioning history, RDS automated backups). Understand the provider's data lifecycle and ensure provider disposal mechanisms align with SI-12.3, or contractually flow down the obligation to the provider.
+
+---
+
+### AU-3.3 — Limit Personally Identifiable Information Elements (Audit Records)
+
+**NIST 800-53 Rev 5 Control:** Limit personally identifiable information contained in audit records to the following elements identified in the privacy risk assessment: [organization-defined elements].
+
+**CJIS v6.0 Reference:** PII-in-log minimization; intersects with AU-6 (implementation-level delta requiring weekly review and 1-year retention).
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High's AU-3 base control requires specific content in audit records (timestamp, event type, source, outcome, identity) but does not impose PII minimization within those records. FedRAMP audit records can therefore contain significant PII, bounded only by the AU-3 minimums and organizational practice.
+
+#### CJIS v6.0 Requirement
+
+Audit records must contain only the PII elements identified as necessary in the privacy risk assessment. The intent is that log contents themselves do not become a secondary privacy exposure. For CJI, audit logs typically need to record who queried what case, when, from where, and the action's outcome — not the full query response payload.
+
+#### Implementation Guidance
+
+1. **Conduct the privacy risk assessment for audit records.** RA-3 output defines which PII elements are permissible in logs. Typical permitted set: user identifier, action, object identifier (case ID, record ID), timestamp, source IP or host. Typical excluded set: full CJI payload, fingerprint template data, full criminal history return, photo data.
+2. **Separate identity from content.** Log the object ID, not the object content. The audit log says "user X accessed record Y at time T"; the content of record Y is not stored inline in the log. If content is needed for investigation, reconstruct via the record ID against the primary data store.
+3. **Sanitize at the logging layer.** Application code that writes audit records should construct log payloads from the permitted-elements list explicitly, not dump the full request/response object. Implicit logging (Python `logger.info(request)` with a full PII-bearing object) is a common source of leakage.
+4. **Apply to aggregated and exported logs.** If audit data is exported to a SIEM or central logging platform, the minimization applies to those copies too. Masking or transformation before export is preferable to retroactive redaction.
+5. **Reconcile with AU-6 retention.** CJIS requires 1-year minimum retention for CJI audit events. Minimized logs are still subject to this. The interplay: minimize content, preserve necessary elements, retain for the full period.
+
+#### Evidence Required
+
+- **Privacy risk assessment output** (RA-3) defining permitted audit record elements for AU-3.3 parameter (au-03.03_odp).
+- **Audit record schema** documenting the permitted element set.
+- **Sample audit records** showing permitted elements only; no full CJI payloads.
+- **SIEM or central logging configuration** demonstrating minimization in exported copies.
+- **Code review or logging library standards** showing sanitization at the logging boundary.
+
+#### Key Considerations
+
+- **Tension with thorough audit.** A responder investigating a suspicious access may want the full query payload, not just the object ID. Design the logging architecture to support just-in-time retrieval of the content via the object ID rather than preserving it inline. This preserves investigative capability without inflating the audit log's privacy risk.
+- **Log volume and retention cost.** Paradoxically, minimization reduces storage costs and eases 1-year retention compliance (AU-6 implementation-level delta) since logs are smaller.
+- **Propagation into SIEM.** If CJI-minimized logs feed a SIEM, the SIEM's privacy posture inherits the minimization. If the SIEM enriches with additional context (geolocation, user profile), those enrichments must not reintroduce excluded PII.
+
+---
+
+### PE-8.3 — Limit Personally Identifiable Information Elements (Visitor Access Records)
+
+**NIST 800-53 Rev 5 Control:** Limit personally identifiable information contained in visitor access records to the following elements identified in the privacy risk assessment: [organization-defined elements].
+
+**CJIS v6.0 Reference:** PII-in-visitor-log minimization; applies to facilities where CJI is stored or processed.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High's PE-8 base control requires visitor access records to be maintained for a defined period, with defined content (name, purpose of visit, name of escort, date/time). FedRAMP does not require minimizing PII within those records beyond the baseline content.
+
+#### CJIS v6.0 Requirement
+
+Visitor access records for facilities hosting CJI must contain only the PII elements identified in the privacy risk assessment as operationally necessary. Excess identifiers (for example, SSN, DOB, full driver's license number) must not be collected or retained in visitor logs if they are not required for the access control purpose.
+
+#### Implementation Guidance
+
+1. **Define permitted visitor record elements via RA-3.** Typical permitted set: name, employer or agency affiliation, purpose of visit, escort, date/time of entry/exit. Typical excluded set: SSN, DOB, full driver's license number, photograph (unless operationally required for access control).
+2. **Update visitor management system configuration.** Many commercial visitor management systems capture by default more than is needed. Configure the system to collect only the permitted elements.
+3. **Physical logs (paper sign-in sheets) follow the same rule.** If the facility uses paper visitor logs, the form must not request excluded elements.
+4. **Align with retention and disposal.** Visitor records are subject to retention schedules. When they reach end-of-retention, apply SI-12.3 disposal techniques. Visitor records are a small but real surface for PII retention drift.
+5. **Communicate the collection rationale.** If visitors ask why specific elements are collected (or not collected), staff should be able to cite the privacy risk assessment rationale.
+
+#### Evidence Required
+
+- **Privacy risk assessment output** (RA-3) defining permitted visitor record elements for PE-8.3 parameter (pe-08.03_odp).
+- **Visitor management system configuration** or sign-in form showing the limited element set.
+- **Sample visitor records** demonstrating compliance.
+- **Retention and disposal documentation** for visitor logs.
+
+#### Key Considerations
+
+- **Escort visits to data centers hosting CJI.** Many cloud-hosted CJIS deployments involve CSP-operated data centers that rarely if ever have agency personnel on-site as visitors. PE-8.3 applies nonetheless to whatever visitor logs exist (for example, CSP-side maintenance vendor visits, agency audit visits, inspectors). The CSP's visitor logging practice is in scope.
+- **Agency-operated facilities (command centers, evidence rooms).** Agencies operating their own CJI-hosting facilities have a more direct PE-8.3 obligation. Visitor traffic is typically higher and the log scrutiny from CJIS auditors is more visible.
+- **Badge-reader logs versus sign-in logs.** Electronic access logs from badge readers typically do not contain PII beyond badge ID, which is not typically considered PII unless linked to the cardholder directly. Those are usually out of PE-8.3 scope, but the linkage table (badge ID to cardholder) that can re-link is in scope for other controls (AC-2, AC-3).
+
+---
+
+### AC-3.14 — Individual Access
+
+**NIST 800-53 Rev 5 Control:** Provide [organization-defined mechanisms] to enable individuals to have access to the following elements of their personally identifiable information: [organization-defined elements].
+
+**CJIS v6.0 Reference:** Subject access to own PII; law-enforcement records exemption recognized in supplemental guidance.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High does not require a subject-access mechanism. U.S. subject access rights are sector-specific (Privacy Act for federal agency records, HIPAA for health, GLBA for financial) and FedRAMP does not generalize them.
+
+#### CJIS v6.0 Requirement
+
+Provide a mechanism enabling individuals to access the organization-defined elements of their own PII. For CJI specifically, the NIST supplemental guidance explicitly recognizes that law enforcement records may be exempt from disclosure under Privacy Act section (j)(2) or state analogues. The control therefore operates as: provide the mechanism; apply the statutory exemptions when responding.
+
+The relationship with SI-18.4 (individual requests for correction/deletion):
+- **AC-3.14 = access** (I want to see what you have about me).
+- **SI-18.4 = correction/deletion** (I want you to fix or remove what you have).
+They are complementary controls; an individual typically exercises access first, then correction.
+
+#### Implementation Guidance
+
+1. **Define the access mechanism.** Typically coordinated with the state CSA. Forms, authentication requirements, fees (if any), response SLAs, and redaction policy should be documented. Exemptions must be pre-catalogued so the response can cite them.
+2. **Authenticate the requester.** Subject access requires strong identity verification — a requester is asking for another person's record if identity is not verified. Typical mechanisms: notarized request, in-person verification with government ID, or AAL2 electronic identity proofing (coordinates with IA-2 implementation-level delta which requires AAL2 for CJI access).
+3. **Route to privacy and legal for adjudication.** Senior agency official for privacy, legal counsel, and often the CJIS Systems Officer review the request. The adjudication determines what is released, what is redacted, what is withheld under exemption.
+4. **Respond with cited exemptions.** If elements are withheld, cite the exemption source (statute or regulation). A plain "no" without citation is non-compliant with typical Privacy Act practice.
+5. **Track the requests.** Volume, response time, approval/partial-approval/denial breakdown; metrics feed privacy program reporting.
+
+#### Evidence Required
+
+- **Documented access mechanism** (forms, authentication requirements, fees, SLA, redaction policy).
+- **Exemption register** cataloguing applicable statutory exemptions.
+- **Sample request records** showing the full workflow (intake, authentication, adjudication, response with citations).
+- **Aggregate metrics** for access requests received and resolved.
+
+#### Key Considerations
+
+- **Law-enforcement records exemption is broad, not absolute.** The Privacy Act (j)(2) exemption applies to maintained systems of records principally compiled for criminal law enforcement purposes. Not every CJI system qualifies; apply the exemption rigorously per statute, not reflexively.
+- **Partial disclosure is common.** Rather than full denial, many responses release non-sensitive elements (for example, arrest date and disposition category) while withholding investigative narrative, informant identity, or other sensitive elements. Partial disclosure requires a more complex redaction workflow.
+- **Identity proofing is the hard part.** Weak authentication at the request intake means someone can request another person's criminal history. Strong identity proofing is operationally burdensome but compliance-critical. Coordinate with IA-2 implementation-level delta's AAL2 guidance for online mechanisms.
+- **Chilling effect to avoid.** An overly burdensome access mechanism may effectively deny the right in practice. Reasonable authentication should not be confused with insurmountable authentication. Courts have found pretextual denial via impossible process to violate subject-access rights.
+
+---
+
+### SC-7.24 — Personally Identifiable Information at Boundaries
+
+**NIST 800-53 Rev 5 Control:** For systems that process personally identifiable information: apply the following processing rules to data elements of personally identifiable information: [organization-defined rules]; monitor for permitted processing at external interfaces and at key internal boundaries; document each processing exception; and review and remove exceptions that are no longer supported.
+
+**CJIS v6.0 Reference:** Boundary-processing rules for CJI; enforcement and monitoring at system interfaces.
+
+#### FedRAMP High Baseline Requirement
+
+Not included. FedRAMP High's SC-7 base control requires boundary protection (firewalls, DMZ architecture) but does not require PII-specific processing rules with exception tracking. FedRAMP's PII boundary posture is generic rather than PII-aware.
+
+#### CJIS v6.0 Requirement
+
+Systems processing CJI must:
+- Define processing rules per CJI data element (what operations are allowed: read, write, dissemination to specific destinations, transformation, retention).
+- Monitor for compliance at external interfaces (for example, API gateway for NCIC queries, state CJIS network interface) and at key internal boundaries (for example, between the CJIS application tier and a database tier, between primary and replica systems).
+- Document exceptions where processing deviates from the rules.
+- Periodically review the exception list and remove stale exceptions.
+
+#### Implementation Guidance
+
+1. **Define processing rules per CJI element class.** Example: "Driver's license numbers may be queried by dispatch; they must not be exported to non-dispatch systems; they must be masked in analytics outputs." Rules are organization-defined (sc-07.24_odp) and must be documented in the SSP.
+2. **Enforce at technical boundaries.** API gateways should be configured with per-element policy. Inter-tier communication should enforce rules (for example, a dispatch tier may not send raw fingerprint data to an analytics tier). This often requires policy-as-code approaches (for example, OPA/Rego at API gateways) that the CSP or agency can demonstrate.
+3. **Monitor at boundaries.** Instrument the boundary with telemetry that records processing attempts and rule evaluation outcomes. This becomes the evidence trail for audit.
+4. **Exception workflow.** When a processing rule must be deviated from (for example, a short-lived integration with a new system), document the exception: what rule, what scope, what compensating control, what expiration date. Exceptions without expiration drift into permanent policy violations.
+5. **Exception review cadence.** Organization-defined; typical quarterly review. Expired exceptions must be closed (either by aligning practice with the rule, extending the exception with justification, or ending the deviating practice).
+
+#### Evidence Required
+
+- **Processing rules documentation** per CJI element class (sc-07.24_odp parameter value).
+- **Boundary configuration** (API gateway policy, inter-tier enforcement rules).
+- **Monitoring telemetry** showing rule evaluation at boundaries.
+- **Exception register** listing each active exception with scope, compensating control, and expiration.
+- **Exception review records** documenting quarterly (or defined-frequency) reviews and closure of stale exceptions.
+
+#### Key Considerations
+
+- **Policy-as-code is the practical enforcement.** Ad-hoc "don't send PII across this boundary" is unenforceable at scale. OPA/Rego, API gateway policy engines, or service-mesh policy provide evaluable rules. This aligns with FedRAMP 20x compliance-as-code direction.
+- **Monitor volume can be very high.** Every CJI query is potentially a boundary evaluation. Sampling or aggregate telemetry may be necessary; full per-request logging may be prohibitive. Design the monitoring plan to balance evidentiary value with operational cost.
+- **Exception drift is the primary failure mode.** Exceptions created for good reasons become permanent in practice because no one reviews. The review cadence is the control's backstop. Without it, SC-7.24 becomes a policy that everyone exempts in practice.
+- **Ties to SI-12.1 (limit PII elements).** SI-12.1 defines what elements are in-scope; SC-7.24 enforces processing rules on those elements at boundaries. The two controls compose: SI-12.1 is the minimization principle, SC-7.24 is the enforcement mechanism at system edges.

--- a/data/cjis-overlay.json
+++ b/data/cjis-overlay.json
@@ -781,6 +781,194 @@
               ]
             }
           ]
+        },
+        {
+          "control-id": "au-3.3",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "au_3_3_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Limit PII Elements in Audit Records",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "au_3_3_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP's AU-3 requires specific audit record content (timestamp, event type, source, outcome, identity) but does not impose PII minimization within audit records."
+                    },
+                    {
+                      "id": "au_3_3_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Audit records must contain only the PII elements identified as necessary in the privacy risk assessment (RA-3). Intent is that log contents themselves do not become a secondary PII exposure. For CJI, typically log the action metadata (who, when, what object, from where) without embedding the full CJI payload."
+                    },
+                    {
+                      "id": "au_3_3_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Conduct RA-3 privacy risk assessment to define permitted audit record elements. Log object identifiers (case ID, record ID) rather than object content. Sanitize at the logging layer so implicit logging (dumping full request/response objects) does not leak PII. Apply minimization to exported log copies (SIEM, central log platform). Reconcile with AU-6 implementation-level delta (1-year retention) so minimized logs still meet retention obligations."
+                    },
+                    {
+                      "id": "au_3_3_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Privacy risk assessment output defining permitted audit record elements; audit record schema documenting the permitted element set; sample audit records showing permitted elements only; SIEM configuration demonstrating minimization in exported copies; logging library standards or code review documentation."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "pe-8.3",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "pe_8_3_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Limit PII Elements in Visitor Access Records",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "pe_8_3_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP's PE-8 requires visitor access records be maintained with defined content (name, purpose, escort, date/time) but does not require minimizing PII within those records."
+                    },
+                    {
+                      "id": "pe_8_3_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Visitor access records for facilities hosting CJI must contain only the PII elements identified in the privacy risk assessment as operationally necessary. Excess identifiers (SSN, DOB, full driver's license, photograph) must not be collected if not required for access control."
+                    },
+                    {
+                      "id": "pe_8_3_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define permitted visitor record elements via RA-3. Configure visitor management systems (and paper sign-in forms) to collect only permitted elements. Align with retention and SI-12.3 disposal schedules. Communicate the collection rationale to visitors who ask."
+                    },
+                    {
+                      "id": "pe_8_3_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Privacy risk assessment output defining permitted visitor record elements; visitor management system configuration or sign-in form showing limited element set; sample visitor records demonstrating compliance; retention and disposal documentation for visitor logs."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "ac-3.14",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "ac_3_14_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — Individual Access to PII",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "ac_3_14_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP does not require a subject-access mechanism. U.S. subject access rights are sector-specific (Privacy Act, HIPAA, GLBA)."
+                    },
+                    {
+                      "id": "ac_3_14_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "Provide a mechanism enabling individuals to access their own PII elements as defined. NIST supplemental guidance recognizes law-enforcement records may be exempt from disclosure under Privacy Act (j)(2) or state analogues; the control operates as: provide the mechanism, apply statutory exemptions when responding."
+                    },
+                    {
+                      "id": "ac_3_14_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define the access mechanism (forms, authentication, fees, SLA, redaction policy) coordinated with the state CSA. Authenticate requesters strongly (notarized request, in-person ID verification, or AAL2 electronic identity proofing per IA-2). Route to privacy official and legal counsel for adjudication. Respond with cited exemptions for withheld elements. Track request volume, response time, and approval breakdown."
+                    },
+                    {
+                      "id": "ac_3_14_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Documented access mechanism (forms, authentication, SLA, redaction policy); exemption register cataloguing applicable statutory exemptions; sample request records showing full workflow from intake through response; aggregate metrics for access requests received and resolved."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "control-id": "sc-7.24",
+          "adds": [
+            {
+              "position": "ending",
+              "parts": [
+                {
+                  "id": "sc_7_24_cjis_delta",
+                  "name": "cjis-delta",
+                  "title": "CJIS v6.0 — PII Processing Rules at Boundaries",
+                  "props": [
+                    {
+                      "name": "delta-category",
+                      "value": "pii-limitation"
+                    },
+                    {
+                      "name": "gap-type",
+                      "value": "control-level-gap"
+                    }
+                  ],
+                  "parts": [
+                    {
+                      "id": "sc_7_24_cjis_baseline",
+                      "name": "baseline-requirement",
+                      "prose": "Not included in FedRAMP High baseline. FedRAMP's SC-7 requires boundary protection (firewalls, DMZ) but not PII-specific processing rules with exception tracking."
+                    },
+                    {
+                      "id": "sc_7_24_cjis_addition",
+                      "name": "cjis-addition",
+                      "prose": "For systems processing CJI: define processing rules per PII element (what operations are allowed), monitor for permitted processing at external interfaces and internal boundaries, document each exception, and periodically review and remove stale exceptions."
+                    },
+                    {
+                      "id": "sc_7_24_cjis_guidance",
+                      "name": "implementation-guidance",
+                      "prose": "Define processing rules per CJI element class in the SSP (sc-07.24_odp parameter). Enforce at technical boundaries (API gateways, inter-tier controls) using policy-as-code where feasible (OPA/Rego, API gateway policies). Instrument boundaries with telemetry to record rule evaluations. Maintain an exception register with scope, compensating control, and expiration. Review exceptions on a defined cadence (typical quarterly) and close stale exceptions."
+                    },
+                    {
+                      "id": "sc_7_24_cjis_evidence",
+                      "name": "evidence-required",
+                      "prose": "Processing rules documentation per CJI element class; boundary configuration (API gateway policy, inter-tier enforcement rules); monitoring telemetry showing rule evaluations; exception register listing active exceptions with scope and expiration; exception review records showing closure of stale exceptions."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary

Documents the 4 PII-limitation controls that CJIS v6.0 imports from NIST 800-53 Rev 5 privacy overlay but FedRAMP High does not include. These controls share a pattern: limit PII exposure in a specific context (audit logs, visitor logs, individual access channel, boundary processing).

- **AU-3.3** Limit PII Elements in Audit Records: log object IDs, not object content; reconcile with AU-6 implementation-level delta 1-year retention.
- **PE-8.3** Limit PII Elements in Visitor Access Records: visitor management system configuration, aligned with SI-12.3 disposal.
- **AC-3.14** Individual Access: subject access mechanism with law-enforcement exemption handling under Privacy Act (j)(2) or state analogues.
- **SC-7.24** PII Processing Rules at Boundaries: policy-as-code enforcement, monitoring telemetry, exception register with review cadence.

Adds 4 new sections to `analysis/gap-analysis.md` under the `## Control-Level Gaps` H2 and 4 new alter entries to `data/cjis-overlay.json` with `gap-type: control-level-gap` and `delta-category: pii-limitation`.

## Controls Addressed

- AU-3.3 Limit Personally Identifiable Information Elements (Audit Records)
- PE-8.3 Limit Personally Identifiable Information Elements (Visitor Access Records)
- AC-3.14 Individual Access
- SC-7.24 Personally Identifiable Information (Boundary Processing)

## Test Plan

- [ ] JSON parses without error
- [ ] All 4 new alters have `gap-type: control-level-gap` and `delta-category: pii-limitation`
- [ ] Each alter has 4 sub-parts
- [ ] Gap-analysis.md renders correctly with new H3 sections
- [ ] AU-3.3 cross-reference to AU-6 implementation-level delta (1-year retention) is accurate
- [ ] SC-7.24 policy-as-code reference aligns with FedRAMP 20x direction

Part of #18